### PR TITLE
Fix bug in single cell extraction

### DIFF
--- a/segmentation/utils/segmentation_utils.py
+++ b/segmentation/utils/segmentation_utils.py
@@ -411,7 +411,7 @@ def extract_single_cell_data(segmentation_labels, image_data,
         normalized['fov'] = fov
         normalized_data = normalized_data.append(normalized)
 
-        return normalized_data, transformed_data
+    return normalized_data, transformed_data
 
 
 def concatenate_csv(base_dir, csv_files, column_name="point", column_values=None):

--- a/segmentation/utils/segmentation_utils_test.py
+++ b/segmentation/utils/segmentation_utils_test.py
@@ -250,3 +250,5 @@ def test_extract_single_cell_data():
 
     normalized, transformed = segmentation_utils.extract_single_cell_data(segmentation_masks,
                                                                           channel_data)
+
+    assert normalized.shape[0] == 7


### PR DESCRIPTION
The recent refactor resulted in a bug where only the first FOV's worth of cells was getting extracted. This PR fixes is. Closes #100 