### PR TITLE
Add more segmentation testing functions

### DIFF
--- a/segmentation/utils/segmentation_utils_test.py
+++ b/segmentation/utils/segmentation_utils_test.py
@@ -262,3 +262,5 @@ def test_extract_single_cell_data():
                                                                           channel_data)
 
     assert normalized.shape[0] == 7
+
+# TODO: add more testing functions to this suite


### PR DESCRIPTION
Addressing issue #101 about adding a more complete set of testing functions to segmentation_utils_test.py. Currently, there are only three functions tested. It would be useful to add more to test the correctness of other functions such as combine_segmentation_masks.