### PR TITLE
Extending Signal Extraction

### DIFF
--- a/segmentation/utils/signal_extraction.py
+++ b/segmentation/utils/signal_extraction.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-
+# TODO: work on weighted extraction and implement other discussed techniques of extraction
 def simple_weighted_extraction(cell_coords, image_data):
     """
     Define a weighted extraction technique based on how close the coordinate is to the center

--- a/segmentation/utils/signal_extraction.py
+++ b/segmentation/utils/signal_extraction.py
@@ -1,16 +1,27 @@
 import numpy as np
 
+
 # TODO: work on weighted extraction and implement other discussed techniques of extraction
-def simple_weighted_extraction(cell_coords, image_data):
+def positive_pixels(cell_coords, image_data):
     """
-    Define a weighted extraction technique based on how close the coordinate is to the center
+    Extract channel counts by summing over the number of non-zero pixels in the cell,
+    improves on default_extraction by not distinguishing between pixel expression values
 
     Args:
-        cell_coords: tuples of values representing pixels within one cell
-        image_data: array containing channel counts
+        cell_coords (tuple): tuples of values representing pixels within one cell
+        image_data (numpy): array containing channel counts
 
     Returns:
-        np.array: sum of counts for each channel
+        channel_counts (numpy): sum of counts for each channel
+    """
+
+    pass
+
+
+def center_weighting(cell_coords, image_data):
+    """
+    Extract channel counts by summing over weighted expression values based on distance from center,
+    improves upon default extraction by including a level of certainty/uncertainty
     """
 
     pass
@@ -21,11 +32,11 @@ def default_extraction(cell_coords, image_data):
     Extract channel counts for an individual cell via basic summation for each channel
 
     Args:
-        cell_coords: tuples of values representing pixels within one cell
-        image_data: array containing channel counts
+        cell_coords (tuple): tuples of values representing pixels within one cell
+        image_data (numpy): array containing channel counts
 
     Returns:
-        np.array: sum of counts for each channel
+        channel_counts (numpy): sum of counts for each channel
     """
 
     # transpose coords so they can be used to index an array

--- a/segmentation/utils/signal_extraction.py
+++ b/segmentation/utils/signal_extraction.py
@@ -1,6 +1,7 @@
 import numpy as np
 from skimage.measure import regionprops
 
+
 # TODO: work on weighted extraction and implement other discussed techniques of extraction
 def positive_pixels_extraction(cell_coords, image_data, threshold=0):
     """

--- a/segmentation/utils/signal_extraction.py
+++ b/segmentation/utils/signal_extraction.py
@@ -2,29 +2,82 @@ import numpy as np
 
 
 # TODO: work on weighted extraction and implement other discussed techniques of extraction
-def positive_pixels(cell_coords, image_data):
+def positive_pixels_extraction(cell_coords, image_data):
     """
     Extract channel counts by summing over the number of non-zero pixels in the cell,
     improves on default_extraction by not distinguishing between pixel expression values
 
     Args:
-        cell_coords (tuple): tuples of values representing pixels within one cell
-        image_data (numpy): array containing channel counts
+        cell_coords (numpy): values representing pixels within one cell
+        image_data (xarray): array containing channel counts
 
     Returns:
         channel_counts (numpy): sum of counts for each channel
     """
 
-    pass
+    # transpose coords so they can be used to index an array
+    cell_coords = cell_coords.T
+    channel_values = image_data.values[tuple(cell_coords)]
+
+    # sum up based on a binary mask that is 1 if the expression value > 0 else 0
+    channel_counts = np.sum(channel_values > 0, axis=0)
+
+    return channel_counts
 
 
-def center_weighting(cell_coords, image_data):
+def center_weighting_extraction(cell_coords, image_data):
     """
     Extract channel counts by summing over weighted expression values based on distance from center,
     improves upon default extraction by including a level of certainty/uncertainty
+
+    Args:
+        cell_coords (numpy): values representing pixels within one cell
+        image_data (xarray): array containing channel counts
+
+    Returns:
+        channel_counts (numpy): sum of counts for each channel
     """
 
-    pass
+    # create a weighting matrix, we will assign the highest value at the center
+    # and decrease by 1 each layer we move away from it
+    # I'm going to be assume we get square matrices in image_data
+    center = int(image_data.shape[0] / 2)
+
+    # this will ensure we never get zero or negative weighting values in our weight matrix
+    center_weight = center + 1
+
+    # now build the weight matrix using ogrid
+    image_row_index, image_col_index = np.ogrid[:image_data.shape[0], :image_data.shape[1]]
+    weight_matrix = center_weight - np.maximum(np.abs(image_row_index - center), np.abs(image_col_index - center))
+
+    # TODO: the center of even-length arrays is not a single pixel which currently causes
+    # minor signal irregularities at different layers
+    # ex. in a 4 x 4 matrix the center should be:
+    # 0 0 0 0
+    # 0 X X 0
+    # 0 X X 0
+    # 0 0 0 0
+
+    # and not:
+    # 0 0 0 0
+    # 0 0 0 0
+    # 0 0 X 0
+    # 0 0 0 0
+    # as would be defined without the correction by the regular signal weighting algorithm
+    # the easy way to fix this is to use skimage.draw.rectangle
+
+    # center the weight matrix by center_weight
+    weight_matrix = weight_matrix / center_weight
+
+    # transpose coords so they can be used to index an array
+    cell_coords = cell_coords.T
+    channel_values = image_data.values[tuple(cell_coords)]
+    weight_values = np.expand_dims(weight_matrix[tuple(cell_coords)], axis=0)
+
+    # multiply channel_values by weight_values and then sum across channels
+    channel_counts = np.sum(np.multiply(channel_values, weight_values.T), axis=0)
+
+    return channel_counts
 
 
 def default_extraction(cell_coords, image_data):
@@ -32,8 +85,8 @@ def default_extraction(cell_coords, image_data):
     Extract channel counts for an individual cell via basic summation for each channel
 
     Args:
-        cell_coords (tuple): tuples of values representing pixels within one cell
-        image_data (numpy): array containing channel counts
+        cell_coords (numpy): values representing pixels within one cell
+        image_data (xarray): array containing channel counts
 
     Returns:
         channel_counts (numpy): sum of counts for each channel

--- a/segmentation/utils/signal_extraction_test.py
+++ b/segmentation/utils/signal_extraction_test.py
@@ -4,17 +4,54 @@ import xarray as xr
 from segmentation.utils import signal_extraction
 
 
+def test_positive_pixels_extraction():
+    # this function tests the functionality of positive pixels extraction
+    # where we count the number of non-zero values for each channel
+
+    # create a series of constant arrays
+    base_channel = np.zeros((10, 10))
+
+    combined_channels = np.stack((base_channel, base_channel + 1, base_channel + 2), axis=-1)
+    combined_channels = xr.DataArray(combined_channels)
+
+    coords = np.stack((np.arange(4), np.arange(4)), axis=-1)
+
+    channel_counts = signal_extraction.positive_pixels_extraction(cell_coords=coords,
+                                                                  image_data=combined_channels)
+
+    assert np.all(channel_counts == [0, 4, 4])
+
+
+def test_center_weighting_extraction():
+    # this function tests the functionality of center weighting extraction
+    # where we add a weighting scheme with more confidence toward the center
+    # before summing across each channel
+
+    # create a series of constant arrays
+    base_channel = np.ones((10, 10))
+
+    combined_channels = np.stack((base_channel, base_channel * 2, base_channel * 4), axis=-1)
+    combined_channels = xr.DataArray(combined_channels)
+
+    coords = np.stack((np.arange(6), np.arange(6)), axis=-1)
+
+    channel_counts = signal_extraction.center_weighting_extraction(cell_coords=coords,
+                                                                   image_data=combined_channels)
+
+    assert np.all(channel_counts == [3.5, 7., 14.])
+
+
 def test_default_extraction():
+    # this function tests the functionality of default weighting extraction
+    # where we just sum across each channel
+
     # create a series of constant arrays
     base_channel = np.ones((10, 10))
 
     combined_channels = np.stack((base_channel, base_channel * 2, base_channel * 5), axis=-1)
     combined_channels = xr.DataArray(combined_channels)
 
-    coords = np.array([[0, 0],
-                       [1, 1],
-                       [2, 2],
-                       [3, 3]])
+    coords = np.stack((np.arange(4), np.arange(4)), axis=-1)
 
     channel_counts = signal_extraction.default_extraction(cell_coords=coords,
                                                           image_data=combined_channels)

--- a/segmentation/utils/signal_extraction_test.py
+++ b/segmentation/utils/signal_extraction_test.py
@@ -92,7 +92,7 @@ def test_center_weighting_extraction():
 
     # a lot of this is pretty clunky right now, but essentially we're testing here that
     # weighted extraction indeed leads to less confidence beyond the border of the nucleus
-    # or membrane depending on whether 
+    # or membrane depending on whether
 
     # extract the cell regions for cells 1 and 2
     coords_1 = np.argwhere(sample_segmentation_mask == 1)

--- a/segmentation/utils/signal_extraction_test.py
+++ b/segmentation/utils/signal_extraction_test.py
@@ -2,24 +2,66 @@ import numpy as np
 import xarray as xr
 
 from segmentation.utils import signal_extraction
+from segmentation.utils import synthetic_spatial_datagen
+
+from skimage.measure import regionprops
+from skimage.draw import circle_perimeter
 
 
 def test_positive_pixels_extraction():
     # this function tests the functionality of positive pixels extraction
     # where we count the number of non-zero values for each channel
 
-    # create a series of constant arrays
-    base_channel = np.zeros((10, 10))
+    # configure your parameters here
+    size_img = (1024, 1024)
+    cell_radius = 10
+    nuc_radius = 3
+    memb_thickness = 5
+    nuc_signal_strength = 10
+    memb_signal_strength = 100
+    nuc_uncertainty_length = 0
+    memb_uncertainty_length = 0
 
-    combined_channels = np.stack((base_channel, base_channel + 1, base_channel + 2), axis=-1)
-    combined_channels = xr.DataArray(combined_channels)
+    # generate sample segmentation mask and channel data
+    sample_segmentation_mask, sample_channel_data = \
+        synthetic_spatial_datagen.generate_two_cell_test_channel_synthetic_data(size_img=size_img,
+                                                                                cell_radius=cell_radius,
+                                                                                nuc_radius=nuc_radius,
+                                                                                memb_thickness=memb_thickness,
+                                                                                nuc_signal_strength=nuc_signal_strength,
+                                                                                memb_signal_strength=memb_signal_strength,
+                                                                                nuc_uncertainty_length=nuc_uncertainty_length,
+                                                                                memb_uncertainty_length=memb_uncertainty_length)
 
-    coords = np.stack((np.arange(4), np.arange(4)), axis=-1)
+    # extract the cell regions for cells 1 and 2
+    coords_1 = np.argwhere(sample_segmentation_mask == 1)
+    coords_2 = np.argwhere(sample_segmentation_mask == 2)
 
-    channel_counts = signal_extraction.positive_pixels_extraction(cell_coords=coords,
-                                                                  image_data=combined_channels)
+    # test default extraction (threshold == 0)
+    channel_counts_1 = signal_extraction.positive_pixels_extraction(cell_coords=coords_1,
+                                                                    image_data=xr.DataArray(sample_channel_data))
 
-    assert np.all(channel_counts == [0, 4, 4])
+    channel_counts_2 = signal_extraction.positive_pixels_extraction(cell_coords=coords_2,
+                                                                    image_data=xr.DataArray(sample_channel_data))
+
+    # note that for cell 2 it's higher because of membrane-level expression
+    assert np.all(channel_counts_1 == [25, 0])
+    assert np.all(channel_counts_2 == [0, 236])
+
+    # test with new threshold == 10 (because that's what we label nuclear signal for the time being)
+    # nuclear signal extraction should now be 0
+    test_threshold = 10
+
+    channel_counts_1 = signal_extraction.positive_pixels_extraction(cell_coords=coords_1,
+                                                                    image_data=xr.DataArray(sample_channel_data),
+                                                                    threshold=test_threshold)
+
+    channel_counts_2 = signal_extraction.positive_pixels_extraction(cell_coords=coords_2,
+                                                                    image_data=xr.DataArray(sample_channel_data),
+                                                                    threshold=test_threshold)
+
+    assert np.all(channel_counts_1 == [0, 0])
+    assert np.all(channel_counts_2 == [0, 236])
 
 
 def test_center_weighting_extraction():
@@ -27,33 +69,85 @@ def test_center_weighting_extraction():
     # where we add a weighting scheme with more confidence toward the center
     # before summing across each channel
 
-    # create a series of constant arrays
-    base_channel = np.ones((10, 10))
+    # configure your parameters here
+    size_img = (1024, 1024)
+    cell_radius = 10
+    nuc_radius = 3
+    memb_thickness = 5
+    nuc_signal_strength = 10
+    memb_signal_strength = 10
+    nuc_uncertainty_length = 1
+    memb_uncertainty_length = 1
 
-    combined_channels = np.stack((base_channel, base_channel * 2, base_channel * 4), axis=-1)
-    combined_channels = xr.DataArray(combined_channels)
+    # generate sample segmentation mask and channel data
+    sample_segmentation_mask, sample_channel_data = \
+        synthetic_spatial_datagen.generate_two_cell_test_channel_synthetic_data(size_img=size_img,
+                                                                                cell_radius=cell_radius,
+                                                                                nuc_radius=nuc_radius,
+                                                                                memb_thickness=memb_thickness,
+                                                                                nuc_signal_strength=nuc_signal_strength,
+                                                                                memb_signal_strength=memb_signal_strength,
+                                                                                nuc_uncertainty_length=nuc_uncertainty_length,
+                                                                                memb_uncertainty_length=memb_uncertainty_length)
 
-    coords = np.stack((np.arange(6), np.arange(6)), axis=-1)
+    # a lot of this is pretty clunky right now, but essentially we're testing here that
+    # weighted extraction indeed leads to less confidence beyond the border of the nucleus
+    # or membrane depending on whether 
 
-    channel_counts = signal_extraction.center_weighting_extraction(cell_coords=coords,
-                                                                   image_data=combined_channels)
+    # extract the cell regions for cells 1 and 2
+    coords_1 = np.argwhere(sample_segmentation_mask == 1)
+    coords_2 = np.argwhere(sample_segmentation_mask == 2)
 
-    assert np.all(channel_counts == [3.5, 7., 14.])
+    channel_counts_1 = signal_extraction.center_weighting_extraction(cell_coords=coords_1,
+                                                                     image_data=xr.DataArray(sample_channel_data))
+
+    channel_counts_2 = signal_extraction.center_weighting_extraction(cell_coords=coords_2,
+                                                                     image_data=xr.DataArray(sample_channel_data))
+
+    # the reason we get weird values for channel counts 1 is because cell 2 has membrane-level expression
+    # with intentional uncertainty added to it, meaning some of its signal "bleeds" into cell 1's signal
+
+    # TODO: test if this function actually works as intended around the boundaries, aka
+    # the effect of wrong signal being added to a cell is reduced with a center weighting technique
+    assert np.all(channel_counts_1.astype(np.int16) == [448, 88])
+    assert np.all(channel_counts_2.astype(np.int16) == [0, 2329])
 
 
 def test_default_extraction():
     # this function tests the functionality of default weighting extraction
     # where we just sum across each channel
 
-    # create a series of constant arrays
-    base_channel = np.ones((10, 10))
+    # configure your parameters here
+    size_img = (1024, 1024)
+    cell_radius = 10
+    nuc_radius = 3
+    memb_thickness = 5
+    nuc_signal_strength = 10
+    memb_signal_strength = 10
+    nuc_uncertainty_length = 0
+    memb_uncertainty_length = 0
 
-    combined_channels = np.stack((base_channel, base_channel * 2, base_channel * 5), axis=-1)
-    combined_channels = xr.DataArray(combined_channels)
+    # generate sample segmentation mask and channel data
+    sample_segmentation_mask, sample_channel_data = \
+        synthetic_spatial_datagen.generate_two_cell_test_channel_synthetic_data(size_img=size_img,
+                                                                                cell_radius=cell_radius,
+                                                                                nuc_radius=nuc_radius,
+                                                                                memb_thickness=memb_thickness,
+                                                                                nuc_signal_strength=nuc_signal_strength,
+                                                                                memb_signal_strength=memb_signal_strength,
+                                                                                nuc_uncertainty_length=nuc_uncertainty_length,
+                                                                                memb_uncertainty_length=memb_uncertainty_length)
 
-    coords = np.stack((np.arange(4), np.arange(4)), axis=-1)
+    # extract the cell regions for cells 1 and 2
+    coords_1 = np.argwhere(sample_segmentation_mask == 1)
+    coords_2 = np.argwhere(sample_segmentation_mask == 2)
 
-    channel_counts = signal_extraction.default_extraction(cell_coords=coords,
-                                                          image_data=combined_channels)
+    channel_counts_1 = signal_extraction.default_extraction(cell_coords=coords_1,
+                                                            image_data=xr.DataArray(sample_channel_data))
 
-    assert np.all(channel_counts == [4, 8, 20])
+    channel_counts_2 = signal_extraction.default_extraction(cell_coords=coords_2,
+                                                            image_data=xr.DataArray(sample_channel_data))
+
+    # note that for cell 2 it's higher because of membrane-level expression
+    assert np.all(channel_counts_1 == [250, 0])
+    assert np.all(channel_counts_2 == [0, 2360])

--- a/segmentation/utils/synthetic_spatial_datagen.py
+++ b/segmentation/utils/synthetic_spatial_datagen.py
@@ -269,7 +269,8 @@ def generate_two_cell_test_segmentation_mask(size_img=(1024, 1024), cell_radius=
 
 def generate_two_cell_test_nuclear_signal(segmentation_mask, cell_centers,
                                           size_img=(1024, 1024), nuc_cell_ids=[1],
-                                          nuc_radius=3):
+                                          nuc_radius=3, nuc_signal_strength=10,
+                                          nuc_uncertainty_length=0):
     """
     This function generates nuclear signal for the provided cells
 
@@ -279,6 +280,7 @@ def generate_two_cell_test_nuclear_signal(segmentation_mask, cell_centers,
         size_img (tuple): the dimensions of the image we wish to generate
         nuc_cell_ids (list): a list of cells we wish to generate nuclear signal for, if None assume just cell 1
         nuc_radius (int): the radius of the nucleus of each cell
+        nuc_uncertainty_length (int): will extend nuc_radius by the specified length
 
     Returns:
         sample_nuclear_signal (numpy): an array of equal dimensions to segmentation_mask
@@ -293,8 +295,9 @@ def generate_two_cell_test_nuclear_signal(segmentation_mask, cell_centers,
 
         # generate the nuclear region in the middle of the cell with the same cell center
         # and set signal to a uniform value
-        nuc_region_x, nuc_region_y = circle(center[0], center[1], nuc_radius, shape=size_img)
-        sample_nuclear_signal[nuc_region_x, nuc_region_y] = 10
+        nuc_region_x, nuc_region_y = circle(center[0], center[1], nuc_radius + nuc_uncertainty_length,
+                                            shape=size_img)
+        sample_nuclear_signal[nuc_region_x, nuc_region_y] = nuc_signal_strength
 
         # let's keep things simple for now and not include jitter or anything
         # that can easily be included in the next commit
@@ -304,7 +307,8 @@ def generate_two_cell_test_nuclear_signal(segmentation_mask, cell_centers,
 
 def generate_two_cell_test_membrane_signal(segmentation_mask, cell_centers,
                                            size_img=(1024, 1024), cell_radius=10,
-                                           memb_cell_ids=[2], memb_thickness=5):
+                                           memb_cell_ids=[2], memb_thickness=5,
+                                           memb_signal_strength=10, memb_uncertainty_length=0):
     """
     This function generates membrane signal for the provided cells
 
@@ -316,6 +320,7 @@ def generate_two_cell_test_membrane_signal(segmentation_mask, cell_centers,
             for a ring-shaped membrane
         memb_cell_ids (list): a list of cells we wish to generate nuclear signal for, if None assume just cell 2
         memb_thickness (int): the diameter of the membrane ring of each cell
+        memb_uncertainty_length (int): will extend memb_radius by the specified length
 
     Returns:
         sample_membrane_signal (numpy): an array of equal dimensions to segmentation_mask
@@ -330,11 +335,12 @@ def generate_two_cell_test_membrane_signal(segmentation_mask, cell_centers,
 
         # generate both the coordinates of the cell region and non-membrane region
         # for proper circle subtraction to generate membrane
-        cell_region_x, cell_region_y = circle(center[0], center[1], cell_radius, shape=size_img)
-        non_memb_region_x, non_memb_region_y = circle(center[0], center[1], cell_radius - memb_thickness, shape=size_img)
+        cell_region_x, cell_region_y = circle(center[0], center[1], cell_radius + memb_uncertainty_length, shape=size_img)
+        non_memb_region_x, non_memb_region_y = circle(center[0], center[1], cell_radius - memb_thickness,
+                                                      shape=size_img)
 
         # perform circle subtraction
-        sample_membrane_signal[cell_region_x, cell_region_y] = 10
+        sample_membrane_signal[cell_region_x, cell_region_y] = memb_signal_strength
         sample_membrane_signal[non_memb_region_x, non_memb_region_y] = 0
 
         # let's keep things simple for now and not include jitter or anything
@@ -344,7 +350,9 @@ def generate_two_cell_test_membrane_signal(segmentation_mask, cell_centers,
 
 
 def generate_two_cell_test_channel_synthetic_data(size_img=(1024, 1024), cell_radius=10, nuc_radius=3, memb_thickness=5,
-                                                  nuc_cell_ids=[1], memb_cell_ids=[2]):
+                                                  nuc_cell_ids=[1], memb_cell_ids=[2], nuc_signal_strength=10,
+                                                  memb_signal_strength=10, nuc_uncertainty_length=0,
+                                                  memb_uncertainty_length=0):
     """
     This function generates the complete package of channel-level synthetic data we're looking for
 
@@ -355,6 +363,10 @@ def generate_two_cell_test_channel_synthetic_data(size_img=(1024, 1024), cell_ra
         memb_diameter (int): the diameter of each membrane
         nuc_cell_ids (list): a list of which cells we wish to generate nuclear signal for, if None assume just cell 1
         memb_cell_ids (list): a list of which cells we wish to generate membrane signal for, if None assume just cell 2
+        nuc_signal_strength (int): defines the constant value we want to assign to nuclear signal
+        memb_signal_strength (int): defines the constant value we want to assign to membrane signal
+        nuc_uncertainty_length (int): will extend nuc_radius by specified length
+        memb_uncertainty_length (int) will extend memb_radius by specified length
 
     Returns:
         sample_segmentation_mask (numpy): an array which contains the labeled cell regions
@@ -370,13 +382,17 @@ def generate_two_cell_test_channel_synthetic_data(size_img=(1024, 1024), cell_ra
                                                                   cell_centers=sample_cell_centers,
                                                                   size_img=size_img,
                                                                   nuc_cell_ids=nuc_cell_ids,
-                                                                  nuc_radius=nuc_radius)
+                                                                  nuc_radius=nuc_radius,
+                                                                  nuc_signal_strength=nuc_signal_strength,
+                                                                  nuc_uncertainty_length=nuc_uncertainty_length)
     sample_membrane_signal = generate_two_cell_test_membrane_signal(segmentation_mask=sample_segmentation_mask,
                                                                     cell_centers=sample_cell_centers,
                                                                     size_img=size_img,
                                                                     cell_radius=cell_radius,
                                                                     memb_cell_ids=memb_cell_ids,
-                                                                    memb_thickness=memb_thickness)
+                                                                    memb_thickness=memb_thickness,
+                                                                    memb_signal_strength=memb_signal_strength,
+                                                                    memb_uncertainty_length=memb_uncertainty_length)
 
     # generate the channel data matrix
     sample_channel_data = np.zeros((size_img[0], size_img[1], 2))

--- a/segmentation/utils/synthetic_spatial_datagen_test.py
+++ b/segmentation/utils/synthetic_spatial_datagen_test.py
@@ -161,7 +161,7 @@ def test_generate_two_cell_test_nuclear_signal():
                                                                         nuc_signal_strength=nuc_signal_strength,
                                                                         nuc_uncertainty_length=nuc_uncertainty_length)
 
-    assert sample_membrane_signal[sample_cell_centers[1][0], sample_cell_centers[1][1]] == 10
+    assert sample_nuclear_signal[sample_cell_centers[1][0], sample_cell_centers[1][1]] == 10
 
     # because we'll be jittering the signal eventually, we won't test the status of the signal at the nucleus border
     # this kind of hurts the nuc_uncertainty_length test but we'll revisit that when the time comes

--- a/segmentation/utils/synthetic_spatial_datagen_test.py
+++ b/segmentation/utils/synthetic_spatial_datagen_test.py
@@ -156,11 +156,10 @@ def test_generate_two_cell_test_nuclear_signal():
     nuc_uncertainty_length = 1
     sample_nuclear_signal = \
         synthetic_spatial_datagen.generate_two_cell_test_nuclear_signal(segmentation_mask=sample_segmentation_mask,
-                                                                         cell_centers=sample_cell_centers,
-                                                                         cell_radius=cell_radius,
-                                                                         nuc_radius=nuc_radius,
-                                                                         nuc_signal_strength=nuc_signal_strength,
-                                                                         nuc_uncertainty_length=nuc_uncertainty_length)
+                                                                        cell_centers=sample_cell_centers,
+                                                                        nuc_radius=nuc_radius,
+                                                                        nuc_signal_strength=nuc_signal_strength,
+                                                                        nuc_uncertainty_length=nuc_uncertainty_length)
 
     assert sample_membrane_signal[sample_cell_centers[1][0], sample_cell_centers[1][1]] == 10
 
@@ -229,4 +228,4 @@ def test_generate_two_cell_test_channel_synthetic_data():
                                                                                 memb_signal_strength=100)
 
     assert set(sample_channel_data[:, :, 0].flatten().tolist()) == set([0, 10])
-    assert set(sample_channel_data[:, :, 0].flatten().tolist()) == set([0, 100])
+    assert set(sample_channel_data[:, :, 1].flatten().tolist()) == set([0, 100])


### PR DESCRIPTION
Addresses and closes #157.

Now that we've implemented a first pass of channel-level synthetic data generation, it's time to look into more detailed signal extraction techniques.

Currently, we're naively summing across all channels. As #157 outlines, we should start by working on more nuanced signal extraction techniques that can lend us more information.